### PR TITLE
Add luhn function

### DIFF
--- a/htdocs/core/lib/functions.lib.php
+++ b/htdocs/core/lib/functions.lib.php
@@ -111,6 +111,33 @@ if (!function_exists('str_contains')) {
 	}
 }
 
+/**
+ * Return if the value has a valid Luhn check digit
+ *
+ * @param string|int $value Value to validate
+ * @return bool		True if the luhn check digit is valid
+ * @since Dolibarr V20
+ */
+function validate_luhn($value)
+{
+	$value = (string) $value;// Make sure it is a string.
+	// Validate the Luhn check digit
+	// - Double digit value every other digit.
+	// - Compute the sum
+	$sum = 0;
+	$even = false;
+	for ($i = strlen($value) - 1; $i >= 0; $i--) {
+		$num = (int) $value[$i];
+		if ($even) {
+			$num *= 2;
+			$num = ($num % 10) + (int) ($num / 10);
+		}
+		$even = !$even;
+		$sum += $num;
+	}
+	return ( ($sum % 10) == 0 );
+}
+
 
 /**
  * Return the full path of the directory where a module (or an object of a module) stores its files. Path may depends on the entity if a multicompany module is enabled.


### PR DESCRIPTION
Here is a Luhn validation function that I use in one of my project.

For info: a SIREN has 1 luhn digit and a SIRET has 2 because it includes the SIREN.

So for complete SIRET validation, validate that the length is 14, validate the first 9 digits as a valid number and the full 14 digits as a valid number.